### PR TITLE
Distinguish "probably" and "possibly"

### DIFF
--- a/src/constants.php
+++ b/src/constants.php
@@ -14,4 +14,5 @@ define('not', false);
 define('✘', false);
 define('maybe', (bool)rand(0, 1));
 define('perhaps', (bool)rand(0, 1));
-define('possibly', (bool)rand(0, 2));
+define('possibly', (bool)rand(0, 2)===1);
+define('probably', (bool)rand(0, 2));


### PR DESCRIPTION
"Possibly" should be a lower chance - possible, but unlikely (33% chance).

For legacy behavior, one may use the new "probably" constant which is a 66% chance.
