### PR TITLE
Remove version constraint from the installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 # Installation
 
 ```
-composer require elfet/cherimola:~1
+composer require elfet/cherimola
 ```
 
 # Documentation


### PR DESCRIPTION
If one was to copy and paste the Composer installation command from the README when it has the `~1` version constraint they might be confused as to why they don't get all the functionality shown in the docs. Removing the version constraint will have Composer install the latest tagged version and thus they should get all the current functionality.
